### PR TITLE
Add the possibility to plug the velocity from device to dynamic.

### DIFF
--- a/src/dynamic_graph/sot/dynamics/humanoid_robot.py
+++ b/src/dynamic_graph/sot/dynamics/humanoid_robot.py
@@ -104,6 +104,10 @@ class AbstractHumanoidRobot (object):
     """
     enableVelocityDerivator = False
     """
+    plug the velocity from device to dynamic
+    """
+    plugVelocityFromDevice = False
+    """
     Enable acceleration computation.
     """
     enableAccelerationDerivator = False
@@ -248,6 +252,8 @@ class AbstractHumanoidRobot (object):
             self.velocityDerivator.dt.value = self.timeStep
             plug(self.device.state, self.velocityDerivator.sin)
             plug(self.velocityDerivator.sout, self.dynamic.velocity)
+        elif self.plugVelocityFromDevice:
+            plug(self.device.velocity, self.dynamic.velocity)
         else:
             self.dynamic.velocity.value = self.dimension*(0.,)
 

--- a/src/dynamic_graph/sot/dynamics/humanoid_robot.py
+++ b/src/dynamic_graph/sot/dynamics/humanoid_robot.py
@@ -253,6 +253,7 @@ class AbstractHumanoidRobot (object):
             plug(self.device.state, self.velocityDerivator.sin)
             plug(self.velocityDerivator.sout, self.dynamic.velocity)
         elif self.plugVelocityFromDevice:
+            self.device.setVelocity(self.dimension*(0.,))
             plug(self.device.velocity, self.dynamic.velocity)
         else:
             self.dynamic.velocity.value = self.dimension*(0.,)


### PR DESCRIPTION
This allows to have the velocity-based signals from dynamic (e.g. angular momentum) without having to use the derivator
